### PR TITLE
Add filetype

### DIFF
--- a/doc/shell_command.txt
+++ b/doc/shell_command.txt
@@ -33,6 +33,9 @@ For example:
 At the top of the buffer will be a line `## Shell:` and the command that you
 entered.  You can edit this line and re-run the command with <F5>
 
+The buffer that comes up will have a `shell-command` 'filetype' so you can
+control the settings in it with FileType |:autocmd|s
+
 To disable the plugin:
 >
    let g:loaded_shell_command = 1

--- a/plugin/shell_command.vim
+++ b/plugin/shell_command.vim
@@ -22,6 +22,7 @@ command! -nargs=0 ShellRerun call ShellCommandRerunAll()
 function! ShellCommandRun(interactive, command) "{{{
   " create a new buffer
   new
+  setfiletype shell-command
 
   " register the new buffer, clean out old buffers
   let s:shell_buffers[bufnr('')] = 0

--- a/plugin/shell_command.vim
+++ b/plugin/shell_command.vim
@@ -48,10 +48,6 @@ function! ShellCommandRun(interactive, command) "{{{
 endfunction "}}}
 
 function! <SID>RunShellCommandHere() "{{{
-  " restore syntax highlighting in case it was reset
-  syntax clear
-  syntax region Comment start=/^\%1l## Shelli\=:/ end=/$/
-
   " get the shell command from the header line
   let l:header = getline(1)
   let l:prefix = matchstr(l:header, '^## Shelli\=:')

--- a/syntax/shell-command.vim
+++ b/syntax/shell-command.vim
@@ -1,0 +1,10 @@
+if version < 600
+  syntax clear
+elseif exists("b:current_syntax")
+  finish
+endif
+
+syn match shComment "^##.*$"
+
+
+hi def link shComment Comment

--- a/syntax/shell-command.vim
+++ b/syntax/shell-command.vim
@@ -4,7 +4,4 @@ elseif exists("b:current_syntax")
   finish
 endif
 
-syn match shComment "^##.*$"
-
-
-hi def link shComment Comment
+syntax region Comment start=/^\%1l## Shelli\=:/ end=/$/


### PR DESCRIPTION
Give the created buffer a `filetype` so that `autocmd`s can be specified to run on buffer creation.

The main use of this would be to be able to control the activation of other plugins within the Shell output buffer.

For my case specifically I would want to remove my 80 char ruler highlight and my Indentation highlights